### PR TITLE
improve dequeuer requests_methods

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ try:
 except ImportError:
     from distutils.core import setup
 
-version = '0.3.0'
+version = '0.3.1'
 
 
 def pip_git_to_setuptools_git(url):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -83,7 +83,12 @@ def dequeuer(config):
         )
     )
 
-    d = DequeueToAPI(
+    class MyDequeuer(DequeueToAPI):
+        @property
+        def requests_headers(self):
+            return {'Authorization': 'token TEST-TOKEN'}
+
+    d = MyDequeuer(
         config, 'TEST QUEUE',
         process_pool_size=0,  # Do not use multiprocessing.
         thread_pool_size=0,  # Do not use threads.
@@ -92,8 +97,15 @@ def dequeuer(config):
         aws_region='AWS_REGION'
     )
 
-    for method_name in d.request_methods:
-        d.request_methods[method_name] = mocked_requests_method
+    mocked_requests_module = mock.Mock(
+        get=mocked_requests_method,
+        post=mocked_requests_method,
+        patch=mocked_requests_method,
+        delete=mocked_requests_method,
+    )
+    d.mocked_requests_module = mocked_requests_module
+    d.mocked_requests_method = mocked_requests_method
+    d.load_request_methods(mocked_requests_module)
 
     return d
 

--- a/tests/test_dequeuer.py
+++ b/tests/test_dequeuer.py
@@ -1,12 +1,14 @@
 def test_handle_message__patch(dequeuer, update_message):
     dequeuer.handle_message(update_message)
 
-    assert dequeuer.request_methods['patch'].call_count == 1
+    method = dequeuer.mocked_requests_module.patch
+    assert method.call_count == 1
     assert update_message.delete.call_count == 1
 
 
 def test_handle_message__post(dequeuer, create_message):
     dequeuer.handle_message(create_message)
 
-    assert dequeuer.request_methods['post'].call_count == 1
+    method = dequeuer.mocked_requests_module.post
+    assert method.call_count == 1
     assert create_message.delete.call_count == 1

--- a/tests/test_request_methods.py
+++ b/tests/test_request_methods.py
@@ -1,0 +1,9 @@
+def test_get_method(dequeuer):
+    dequeuer.request_methods['get']('https://example.com/')
+
+    mocked_get = dequeuer.mocked_requests_method
+    assert mocked_get.call_count == 1
+
+    args, kwargs = mocked_get.call_args
+    assert args[0] == 'https://example.com/'
+    assert 'Authorization' in kwargs['headers']


### PR DESCRIPTION
So plugins don't need to insert authentication headers for requests all the time nor call `raise_for_status` after getting the requests response.