### PR TITLE
add regexps to topic names

### DIFF
--- a/powerlibs/aws/sqs/dequeue_to_api/__init__.py
+++ b/powerlibs/aws/sqs/dequeue_to_api/__init__.py
@@ -4,6 +4,7 @@ import glob
 import importlib
 import json
 import os.path
+import re
 import sys
 
 import requests
@@ -125,7 +126,8 @@ class DequeueToAPI(SQSDequeuer):
     def get_actions_for_topic(self, topic, payload):
         for topic_name, actions in self.topics.items():
             expanded_topic_name = topic_name.format(config=self.config, payload=payload)
-            if expanded_topic_name == topic:
+
+            if re.match(expanded_topic_name, topic):
                 for action_name, action_data in actions:
                     self.hydrate_action(action_data, payload)
                     yield (action_name, action_data)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ try:
 except ImportError:
     from distutils.core import setup
 
-version = '0.3.1'
+version = '0.3.2'
 
 
 def pip_git_to_setuptools_git(url):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,6 +69,11 @@ def config():
                     'status': 'created',
                     'parent': '{payload[id]}',
                 }
+            },
+            'test_regexp_matching': {
+                'topic': 'object__\w+',
+                'endpoint': 'test/',
+                'method': 'POST',
             }
         }
     }

--- a/tests/test_topic_matching.py
+++ b/tests/test_topic_matching.py
@@ -1,0 +1,8 @@
+def test_topic_regexp_matching(dequeuer):
+    msg = {'company_name': 'test_company'}
+    actions_1 = tuple(dequeuer.get_actions_for_topic('object__created', msg))
+    actions_2 = tuple(dequeuer.get_actions_for_topic('object__deleted', msg))
+    actions_3 = tuple(dequeuer.get_actions_for_topic('otherthing__created', msg))
+
+    assert actions_1 == actions_2
+    assert actions_1 != actions_3


### PR DESCRIPTION
Because there are some actions that apply to multiple status names, for example.