### PR TITLE
change plugins directory structure to support richier plugins data

### DIFF
--- a/powerlibs/aws/sqs/dequeue_to_api/__init__.py
+++ b/powerlibs/aws/sqs/dequeue_to_api/__init__.py
@@ -105,13 +105,13 @@ class DequeueToAPI(SQSDequeuer):
 
         sys.path.append(path)
 
-        globbing_str = '{}/*.py'.format(path)
+        globbing_str = '{}/*/plugin.py'.format(path)
         for filepath in glob.glob(globbing_str):
-            filename = os.path.basename(filepath)
-            name, extension = os.path.splitext(filename)
-            module = importlib.import_module(name)
+            dirname = os.path.basename(os.path.dirname(filepath))
+            module_name = '{}.plugin'.format(dirname)
+            module = importlib.import_module(module_name)
             the_plugin_class = getattr(module, 'Plugin')
-            self.custom_handlers[name] = the_plugin_class(self)
+            self.custom_handlers[dirname] = the_plugin_class(self)
 
     def get_custom_handler(self, name):
         if name not in self.custom_handlers:

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ try:
 except ImportError:
     from distutils.core import setup
 
-version = '0.4.0'
+version = '0.5.0'
 
 
 def pip_git_to_setuptools_git(url):


### PR DESCRIPTION
Now a plugin should follow this directory structure:

```
plugins
 +- plugin_foo
        +- plugin.py
```

This way we can include a `requirements.txt` file, too, or any other things we consider useful.