### PR TITLE
Allow re groups on topic names

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ try:
 except ImportError:
     from distutils.core import setup
 
-version = '0.5.1'
+version = '0.6.0'
 
 
 def pip_git_to_setuptools_git(url):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -75,6 +75,15 @@ def config():
                 'topic': 'object__\w+',
                 'endpoint': 'test/',
                 'method': 'POST',
+            },
+            'test_regexp_matching_with_groups': {
+                'topic': 'step__(?P<step_name>[^_]+)__(?P<step_status>[^_]+)',
+                'endpoint': 'steps/',
+                'method': 'POST',
+                'payload': {
+                    'status': '{_topic_groups[step_status]}',
+                    'name': '{_topic_groups[step_name]}'
+                }
             }
         }
     }

--- a/tests/test_topic_matching.py
+++ b/tests/test_topic_matching.py
@@ -6,3 +6,20 @@ def test_topic_regexp_matching(dequeuer):
 
     assert actions_1 == actions_2
     assert actions_1 != actions_3
+
+
+def test_topic_regexp_matching_with_groups(dequeuer):
+    msg = {'company_name': 'test_company'}
+    actions_1 = tuple(dequeuer.get_actions_for_topic('step__alfa__started', msg))
+
+    payload = actions_1[0][1]['run'].args[2][0]
+    assert 'name' in payload
+    assert payload['name'] == 'alfa'
+    assert 'status' in payload
+    assert payload['status'] == 'started', payload
+
+    actions_2 = tuple(dequeuer.get_actions_for_topic('step__beta__finished', msg))
+    actions_3 = tuple(dequeuer.get_actions_for_topic('otherthing__created', msg))
+
+    assert actions_1 == actions_2
+    assert actions_1 != actions_3


### PR DESCRIPTION
And got rid of some unnecessary dynamic function definitions inside some methods.

Now the topics can be like `step__(?<step_name>.+)__(?<step_status>.+)` and the payload template can access these values like `{_topic_groups[step_name]}`.