### PR TITLE
allow optional payload template keys

### DIFF
--- a/powerlibs/aws/sqs/dequeue_to_api/__init__.py
+++ b/powerlibs/aws/sqs/dequeue_to_api/__init__.py
@@ -58,12 +58,23 @@ class DequeueToAPI(SQSDequeuer):
     def apply_payload_template(self, payload_template, topic, topic_groups, action, payload):
         hydrated_payload = {}
         for key, value in payload_template.items():
-            hydrated_payload[key] = value.format(
-                _topic=topic,
-                _topic_groups=topic_groups,
-                _action=action,
-                **payload
-            )
+
+            optional = False
+            if value.startswith('OPTIONAL:'):
+                optional = True
+                value = value.replace('OPTIONAL:', '')
+
+            try:
+                hydrated_payload[key] = value.format(
+                    _topic=topic,
+                    _topic_groups=topic_groups,
+                    _action=action,
+                    **payload
+                )
+            except KeyError as ex:
+                if optional:
+                    continue
+                raise ex
 
         return hydrated_payload
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,6 +48,18 @@ def create_message():
 
 
 @pytest.fixture
+def born_message():
+    return Message(
+        {
+            'id': 1,
+            'parent_id': 2,
+            'company_name': 'mycompany',
+        },
+        {'topic': {'StringValue': 'mycompany__child_is_born'}}
+    )
+
+
+@pytest.fixture
 def config():
     return {
         'config': {
@@ -60,6 +72,7 @@ def config():
                 'method': 'PATCH',
                 'payload': {
                     'status': 'new status',
+                    'foobar': 'OPTIONAL:{payload[foobar]}'
                 }
             },
             'create_status': {
@@ -84,7 +97,16 @@ def config():
                     'status': '{_topic_groups[step_status]}',
                     'name': '{_topic_groups[step_name]}'
                 }
-            }
+            },
+            'test_not_optional_missing': {
+                'topic': '{payload[company_name]}__child_is_born',
+                'endpoint': 'parents/{payload[parent_id]}',
+                'method': 'PATCH',
+                'payload': {
+                    'status': 'new status',
+                    'foobar_not_optional': '{payload[foobar]}'
+                }
+            },
         }
     }
 

--- a/tests/test_dequeuer.py
+++ b/tests/test_dequeuer.py
@@ -1,3 +1,6 @@
+import pytest
+
+
 def test_handle_message__patch(dequeuer, update_message):
     dequeuer.handle_message(update_message)
 
@@ -12,3 +15,8 @@ def test_handle_message__post(dequeuer, create_message):
     method = dequeuer.mocked_requests_module.post
     assert method.call_count == 1
     assert create_message.delete.call_count == 1
+
+
+def test_handle_message_without_necessary_key(dequeuer, born_message):
+    with pytest.raises(KeyError):
+        dequeuer.handle_message(born_message)


### PR DESCRIPTION
Now one can mark some value on a payload template as "OPTIONAL", meaning it simply won't be added to the final payload if the asked values (from the value) are not reachable.